### PR TITLE
Deprecation warning at moment js initialization

### DIFF
--- a/server/services/service.js
+++ b/server/services/service.js
@@ -1,5 +1,6 @@
 'use strict';
 const moment = require('moment');
+const dateFormat = 'YYYY-MM-DD';
 
 function getPluginStore() {
   return strapi.store({
@@ -16,7 +17,7 @@ async function createDefaultConfig() {
 }
 
 module.exports = () => ({
-  async getData(date) {
+  async getData(date = new Date()) {
     const pluginStore = getPluginStore();
     let config = await pluginStore.get({key: 'settings'});
     if (!config) return [];
@@ -25,8 +26,8 @@ module.exports = () => ({
       $and: [
         {
           [config.startField]: {
-            $gte: moment(date ?? moment()).startOf('month').subtract(1, 'month').format(),
-            $lte: moment(date ?? moment()).endOf('month').add(1, 'month').format(),
+            $gte: moment(date, dateFormat).startOf('month').subtract(1, 'month').format(),
+            $lte: moment(date, dateFormat).endOf('month').add(1, 'month').format(),
           },
         },
       ],


### PR DESCRIPTION
Adding date format on moment initialization in order to prevent the following log message:
```
Deprecation warning: value provided is not in a recognized RFC2822 or ISO format. moment construction falls back to js Date(), which is not reliable across all browsers and versions. Non RFC2822/ISO date formats are discouraged. Please refer to http://momentjs.com/guides/#/warnings/js-date/ for more info.
Arguments: 
[0] _isAMomentObject: true, _isUTC: false, _useUTC: false, _l: undefined, _i: Sep 28, 2022, _f: undefined, _strict: undefined, _locale: [object Object]
````