### PR TITLE
Adjust node restrictions

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     }
   ],
   "engines": {
-    "node": ">=12.x.x <=16.x.x",
+    "node": ">=12.x.x",
     "npm": ">=6.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
As stated in #19, strapi-calendar is currently not runnable on node > 16,
this PR adjusts the engines it can run on.

I've tested it on node 18 and it works as expected