### PR TITLE
Add full day duration

### DIFF
--- a/admin/src/pages/settings.js
+++ b/admin/src/pages/settings.js
@@ -298,6 +298,12 @@ function Settings() {
                         defaultMessage: '2 Hours',
                       })}
                     </Option>
+					<Option value={1440}>
+					  {formatMessage({
+					    id: getTrad('view.settings.section.general.default-duration.fullday'),
+					    defaultMessage: 'Full Day',
+					  })}
+					</Option>                    
                   </Select>
                 </GridItem>
               </Grid>

--- a/admin/src/pages/settings.js
+++ b/admin/src/pages/settings.js
@@ -300,11 +300,11 @@ function Settings() {
                       })}
                     </Option>
                     <Option value={1440}>
-					  					{formatMessage({
-					    					id: getTrad('view.settings.section.general.default-duration.fullday'),
-					    					defaultMessage: 'Full Day',
-					  					})}
-										</Option>                    
+                      {formatMessage({
+                    	   id: getTrad('view.settings.section.general.default-duration.fullday'),
+                    	   defaultMessage: 'Full Day',
+                      })}
+                    </Option>                   
                   </Select>
                 </GridItem>
               </Grid>

--- a/admin/src/pages/settings.js
+++ b/admin/src/pages/settings.js
@@ -61,6 +61,7 @@ function Settings() {
     titleField: null,
     colorField: null,
     defaultDuration: 30,
+    defaultStartTime: '12:00',    
     drafts: true,
     startHour: '0:00',
     endHour: '23:59',
@@ -298,12 +299,12 @@ function Settings() {
                         defaultMessage: '2 Hours',
                       })}
                     </Option>
-					<Option value={1440}>
-					  {formatMessage({
-					    id: getTrad('view.settings.section.general.default-duration.fullday'),
-					    defaultMessage: 'Full Day',
-					  })}
-					</Option>                    
+                    <Option value={1440}>
+					  					{formatMessage({
+					    					id: getTrad('view.settings.section.general.default-duration.fullday'),
+					    					defaultMessage: 'Full Day',
+					  					})}
+										</Option>                    
                   </Select>
                 </GridItem>
               </Grid>
@@ -378,7 +379,7 @@ function Settings() {
                       ))}
                   </Select>
                 </GridItem>
-              </Grid>
+              </Grid>              
               <Box paddingTop={3}>
                 <ToggleInput
                   label={formatMessage({

--- a/admin/src/translations/de.json
+++ b/admin/src/translations/de.json
@@ -25,6 +25,7 @@
   "view.settings.section.general.default-duration.1h": "1 Stunde",
   "view.settings.section.general.default-duration.1.5h": "1,5 Stunden",
   "view.settings.section.general.default-duration.2h": "2 Stunden",
+  "view.settings.section.general.default-duration.fullDay": "Ganztägig",  
   "view.settings.section.general.start.label": "Start-Feld auswählen",
   "view.settings.section.general.end.label": "Ende-Feld auswählen",
   "view.settings.section.general.end.none": "Kein Ende-Feld",

--- a/admin/src/translations/en.json
+++ b/admin/src/translations/en.json
@@ -26,6 +26,7 @@
   "view.settings.section.general.default-duration.1h": "1 Hour",
   "view.settings.section.general.default-duration.1.5h": "1.5 Hours",
   "view.settings.section.general.default-duration.2h": "2 Hours",
+  "view.settings.section.general.default-duration.fullDay": "Full Day",
   "view.settings.section.general.start.label": "Choose your start field",
   "view.settings.section.general.end.label": "Choose your end field",
   "view.settings.section.general.end.none": "No end field",

--- a/admin/src/translations/es.json
+++ b/admin/src/translations/es.json
@@ -26,6 +26,7 @@
   "view.settings.section.general.default-duration.1h": "1 hora",
   "view.settings.section.general.default-duration.1.5h": "1,5 horas",
   "view.settings.section.general.default-duration.2h": "2 horas",
+  "view.settings.section.general.default-duration.fullDay": "Todo el día",  
   "view.settings.section.general.start.label": "Elija su campo de comienzo",
   "view.settings.section.general.end.label": "Elija su campo de finalización",
   "view.settings.section.general.end.none": "Sin campo de finalización",

--- a/server/services/service.js
+++ b/server/services/service.js
@@ -74,18 +74,25 @@ module.exports = () => ({
       if (config.drafts) return true;
       return x.publishedAt;
     });
+		return dataFiltered.map((x) => {
+			const startDate = x[config.startField].split('T')[0];
+			const endDate = config.endField ? x[config.endField].split('T')[0] : null; 
 
-    return dataFiltered.map((x) => ({
-      id: x.id,
-      title: config.titleField ? x[config.titleField] : config.startField,
-      startDate: x[config.startField],
-      endDate: config.endField
-        ? x[config.endField]
-        : config.defaultDuration === 'fullDay' 
- 			? moment(x[config.startField]).endOf('day')         
-        	: moment(x[config.startField]).add(config.defaultDuration, 'minutes'),
-      color: config.colorField ? x[config.colorField] : null,
-    }));
+			const isMultiDay = endDate && moment(endDate).isAfter(startDate); 
+			const startDateTime = `${startDate}T00:00:00`; 
+			const endDateTime = isMultiDay ? `${endDate}T00:00:00` : moment(startDateTime).add(config.defaultDuration, 'minutes').format(); 
+
+			return {
+			    id: x.id,
+			    title: config.titleField ? x[config.titleField] : x[config.startField],
+			    startDate: startDateTime,
+			    endDate: endDateTime,
+			    color: config.colorField ? x[config.colorField] : null,
+			    allDay: isMultiDay, 
+			};
+
+		});
+
   },
   async getCollections() {
     const types = strapi.contentTypes;

--- a/server/services/service.js
+++ b/server/services/service.js
@@ -74,25 +74,21 @@ module.exports = () => ({
       if (config.drafts) return true;
       return x.publishedAt;
     });
-		return dataFiltered.map((x) => {
-			const startDate = x[config.startField].split('T')[0];
-			const endDate = config.endField ? x[config.endField].split('T')[0] : null; 
-
-			const isMultiDay = endDate && moment(endDate).isAfter(startDate); 
-			const startDateTime = `${startDate}T00:00:00`; 
-			const endDateTime = isMultiDay ? `${endDate}T00:00:00` : moment(startDateTime).add(config.defaultDuration, 'minutes').format(); 
-
-			return {
-			    id: x.id,
-			    title: config.titleField ? x[config.titleField] : x[config.startField],
-			    startDate: startDateTime,
-			    endDate: endDateTime,
-			    color: config.colorField ? x[config.colorField] : null,
-			    allDay: isMultiDay, 
-			};
-
-		});
-
+    return dataFiltered.map((x) => {
+      const startDate = x[config.startField].split('T')[0];
+      const endDate = config.endField ? x[config.endField].split('T')[0] : null; 
+      const isMultiDay = endDate && moment(endDate).isAfter(startDate); 
+      const startDateTime = `${startDate}T00:00:00`; 
+      const endDateTime = isMultiDay ? `${endDate}T00:00:00` : moment(startDateTime).add(config.defaultDuration, 'minutes').format(); 
+      return {
+         id: x.id,
+         title: config.titleField ? x[config.titleField] : x[config.startField],
+         startDate: startDateTime,
+         endDate: endDateTime,
+         color: config.colorField ? x[config.colorField] : null,
+         allDay: isMultiDay, 
+      };
+    });
   },
   async getCollections() {
     const types = strapi.contentTypes;

--- a/server/services/service.js
+++ b/server/services/service.js
@@ -81,7 +81,9 @@ module.exports = () => ({
       startDate: x[config.startField],
       endDate: config.endField
         ? x[config.endField]
-        : moment(x[config.startField]).add(config.defaultDuration, 'minutes'),
+        : config.defaultDuration === 'fullDay' 
+ 			? moment(x[config.startField]).endOf('day')         
+        	: moment(x[config.startField]).add(config.defaultDuration, 'minutes'),
       color: config.colorField ? x[config.colorField] : null,
     }));
   },


### PR DESCRIPTION
**Pull Request Response: Code Revision for All-Day Events**

The logic to determine all-day events has been adjusted. Specifically, if an event is deemed full-day, we only use the date part of the startField, ensuring the start and end dates are treated as:

- startDate: ${startDate}T00:00:00
- endDate: ${endDate}T23:59:59

This ensures that the calendar visually represents the entire day block, allowing events to visually span across multiple days correctly.

The default duration is now set to 1440.

"If the event is fullDay, shouldn't it also affect the start?"

Yes, I addressed this by ensuring that for all-day events, the start time is set to midnight (T00:00:00) and the end time is set to one second before the next day (T23:59:59). This change guarantees that the event fills the entire day block on the calendar.

Please let me know what you think, if we need to do any further adjustments etc.

Jacob
